### PR TITLE
Add server entrypoint and fix file newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,24 @@ src/
 This project is licensed under the MIT License.  
 See the [LICENSE](LICENSE) file for details.
 Trigger CI manually
+
+## Watson NLP Emotion Detection Web App
+
+This repository also contains a simple emotion detection service built with Flask.
+It uses IBM Watson Natural Language Understanding to analyze text and return the
+detected emotion in JSON format. A fallback heuristic is provided when Watson
+credentials are not configured.
+
+Run locally:
+
+```bash
+pip install -r requirements.txt
+python -m emotion_detection.webapp
+```
+
+Send a request:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+    -d '{"text": "I am very happy"}' http://localhost:5000/emotion
+```

--- a/alerts.py
+++ b/alerts.py
@@ -1,3 +1,4 @@
 def send_alert(message):
     print(f"[ALERT] {message}")
     # Here you can add email, Slack, or other integrations
+

--- a/emotion_detection/__init__.py
+++ b/emotion_detection/__init__.py
@@ -1,0 +1,5 @@
+"""Package exposing the Watson Emotion Detector and Flask web app."""
+
+from .detector import WatsonEmotionDetector
+
+__all__ = ["WatsonEmotionDetector"]

--- a/emotion_detection/detector.py
+++ b/emotion_detection/detector.py
@@ -1,0 +1,46 @@
+"""Emotion detection module using IBM Watson NLU."""
+# pylint: disable=too-few-public-methods
+import os
+from typing import Dict
+
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_watson import NaturalLanguageUnderstandingV1
+from ibm_watson.natural_language_understanding_v1 import Features, EmotionOptions
+
+class WatsonEmotionDetector:
+    """Detect emotions in text using IBM Watson Natural Language Understanding."""
+
+    def __init__(self, api_key: str | None = None, url: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("WATSON_NLU_API_KEY")
+        self.url = url or os.getenv("WATSON_NLU_URL")
+        self.service = None
+        if self.api_key and self.url:
+            authenticator = IAMAuthenticator(self.api_key)
+            self.service = NaturalLanguageUnderstandingV1(
+                version="2022-04-07", authenticator=authenticator
+            )
+            self.service.set_service_url(self.url)
+
+    def detect(self, text: str) -> Dict[str, float | str]:
+        """Return the dominant emotion and score for the given text."""
+        if not text or not text.strip():
+            raise ValueError("Input text must not be empty")
+
+        if self.service:
+            response = self.service.analyze(
+                text=text,
+                features=Features(emotion=EmotionOptions()),
+            ).get_result()
+            emotions = response["emotion"]["document"]["emotion"]
+            emotion, score = max(emotions.items(), key=lambda pair: pair[1])
+            return {"emotion": emotion, "score": score}
+
+        # Fallback simple heuristic
+        lowered = text.lower()
+        if "happy" in lowered or "joy" in lowered:
+            return {"emotion": "joy", "score": 1.0}
+        if "sad" in lowered:
+            return {"emotion": "sadness", "score": 1.0}
+        if "angry" in lowered or "anger" in lowered:
+            return {"emotion": "anger", "score": 1.0}
+        return {"emotion": "neutral", "score": 1.0}

--- a/emotion_detection/webapp.py
+++ b/emotion_detection/webapp.py
@@ -1,0 +1,24 @@
+"""Flask web app exposing an emotion detection endpoint."""
+from flask import Flask, jsonify, request
+
+from .detector import WatsonEmotionDetector
+
+app = Flask(__name__)
+_detector = WatsonEmotionDetector()
+
+
+@app.route("/emotion", methods=["POST"])
+def emotion():
+    """Return detected emotion for posted JSON text."""
+    data = request.get_json(silent=True)
+    if not data or "text" not in data:
+        return jsonify({"error": "Invalid input"}), 400
+    try:
+        result = _detector.detect(data["text"])
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/logger.py
+++ b/logger.py
@@ -8,3 +8,4 @@ def setup_logger():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
+

--- a/main.py
+++ b/main.py
@@ -17,3 +17,4 @@ def monitor_aws():
 
 if __name__ == "__main__":
     monitor_aws()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 boto3
 flask
 requests
+ibm-watson
+pytest
+pylint

--- a/server.py
+++ b/server.py
@@ -1,0 +1,5 @@
+"""Entry point for running the emotion detection web server."""
+from emotion_detection.webapp import app
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/tests/test_emotion_detector.py
+++ b/tests/test_emotion_detector.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from emotion_detection.detector import WatsonEmotionDetector
+import pytest
+
+
+def test_detect_joy():
+    detector = WatsonEmotionDetector()
+    result = detector.detect("I am very happy today!")
+    assert result["emotion"] == "joy"
+
+
+def test_invalid_input():
+    detector = WatsonEmotionDetector()
+    with pytest.raises(ValueError):
+        detector.detect("")

--- a/web.py
+++ b/web.py
@@ -8,3 +8,4 @@ def index():
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)
+


### PR DESCRIPTION
## Summary
- add `server.py` to run the emotion detection web server
- ensure Python files have terminating newlines

## Testing
- `pytest -q`
- `pylint --disable=import-error emotion_detection/detector.py emotion_detection/webapp.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_68488cd5633083269bf557522623b4c3